### PR TITLE
Grant access to Gamescope socket for Steam Deck OLED

### DIFF
--- a/deploy/flatpak/io.github.dinosaurplanetrecomp.dino_recomp.yml
+++ b/deploy/flatpak/io.github.dinosaurplanetrecomp.dino_recomp.yml
@@ -14,6 +14,8 @@ finish-args:
   #- "--device=dri"
   #- "--device=input"
   - "--filesystem=xdg-config"
+  # required for Gamescope on Steam Deck OLED
+  - "--filesystem=xdg-run/gamescope-0:ro"
 modules:
   - name: DinosaurPlanetRecompiled
     buildsystem: simple


### PR DESCRIPTION
* See https://github.com/flathub/org.DolphinEmu.dolphin-emu/pull/178#issuecomment-1905194043 for more information
* Bug only occurs on the Steam Deck OLED.

To replicate the error, on a Steam Deck OLED, install the Flatpak, launch the recomp in Game Mode, see error. Gamescope Flatpak is primarily used for HDR in other Flatpaks (Dolphin, PrimeHack, Heroic, etc.).

![image](https://github.com/user-attachments/assets/745b9487-b8ed-4d3f-bb55-6e02c152ba92)